### PR TITLE
Fix attr count

### DIFF
--- a/demo/src/DumpApkXml.java
+++ b/demo/src/DumpApkXml.java
@@ -1,0 +1,69 @@
+import fr.xgouchet.axml.CompressedXmlParser;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.w3c.dom.NamedNodeMap;
+
+public class DumpApkXml {
+    public static void main(String[] args) throws IOException {
+        if (args.length == 0) {
+            System.err.println("Usage: java DumpApkXml <file.apk|file.zip> [<path-in-apk>]");
+            System.err.println("       java DumpApkXml <file-containing-entry-from-apk>");
+            System.exit(21);
+        }
+
+        String fileName = args[0];
+        InputStream is = null;
+        ZipFile zip = null;
+
+        if (fileName.endsWith(".apk") || fileName.endsWith(".zip")) {
+            String entryName = args.length > 1? args[1] : "AndroidManifest.xml";
+            zip = new ZipFile(fileName);
+            ZipEntry entry = zip.getEntry(entryName);
+            is = zip.getInputStream(entry);
+        } else {
+            is = new FileInputStream(fileName);
+        }
+
+        try {
+            Document doc = new CompressedXmlParser().parseDOM(is);
+            dumpNode(doc.getChildNodes().item(0), "");
+        }
+        catch (Exception e) {
+            System.err.println("Failed AXML decode: " + e);
+            e.printStackTrace();
+        }
+
+        is.close();
+        if (zip != null) {
+            zip.close();
+        }
+    }
+
+    private static void dumpNode(Node node, String indent) {
+        System.out.println(indent + node.getNodeName() + " " + attrsToString(node.getAttributes()) + " -> " + node.getNodeValue());
+        NodeList children = node.getChildNodes();
+        for (int i = 0, n = children.getLength(); i < n; ++i)
+            dumpNode(children.item(i), indent + "   ");
+    }
+
+    private static String attrsToString(NamedNodeMap attrs) {
+        StringBuilder sb = new StringBuilder();
+        sb.append('[');
+        for (int i = 0, n = attrs.getLength(); i < n; ++i) {
+            if (i != 0)
+                sb.append(", ");
+            Node attr = attrs.item(i);
+            sb.append(attr.getNodeName() + "=" + attr.getNodeValue());
+        }
+        sb.append(']');
+        return sb.toString();
+    }
+}

--- a/library/src/main/java/fr/xgouchet/axml/CompressedXmlParser.java
+++ b/library/src/main/java/fr/xgouchet/axml/CompressedXmlParser.java
@@ -258,7 +258,7 @@ public class CompressedXmlParser {
         // get tag info
         final int uriIdx = getLEWord(mParserOffset + (4 * WORD_SIZE));
         final int nameIdx = getLEWord(mParserOffset + (5 * WORD_SIZE));
-        final int attrCount = getLEWord(mParserOffset + (7 * WORD_SIZE));
+        final int attrCount = getLEShort(mParserOffset + (7 * WORD_SIZE));
 
         final String name = getString(nameIdx);
         String uri, qname;
@@ -437,6 +437,16 @@ public class CompressedXmlParser {
                 | ((mData[off + 2] << 16) & 0x00ff0000)
                 | ((mData[off + 1] << 8) & 0x0000ff00)
                 | ((mData[off + 0] << 0) & 0x000000ff);
+    }
+
+    /**
+     * @param off the offset of the word to read
+     * @return value of a Little Endian 16 bit word from the byte array at offset
+     * off.
+     */
+    private int getLEShort(final int off) {
+        return ((mData[off + 1] << 8) & 0xff00)
+               | ((mData[off + 0] << 0) & 0x00ff);
     }
 
     /**


### PR DESCRIPTION
This fixes an issue experienced with an APK built by the latest encoder (Android Studio 3, Gradle 4.1, Android Gradle Plugin 3.0).  The attribute count was being misread as a value >2^16 rather than its actual value.  After a bit of investigation I discovered that reading only 16-bits from the attribute count field offset resolved the issue.  Looks like the subsequent bytes are (or at least can be) used for content.